### PR TITLE
Refactor sparql queries

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,6 +7,7 @@ COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY ./app /code/app
+COPY ./queries /code/queries
 
 ENV USER=fastapi
 ENV UID=12345

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -1,94 +1,6 @@
-import os
-from rdflib.namespace import (
-    DC,
-    DCTERMS,
-    DOAP,
-    FOAF,
-    SKOS,
-    OWL,
-    RDF,
-    RDFS,
-    VOID,
-    XMLNS,
-    XSD,
-)
-from rdflib import Namespace
-from SPARQLWrapper import SPARQLWrapper, JSON, POST
-
-from . import config
 from . import utils
 from . import model as m
-
-sparql_writer = SPARQLWrapper(config.UPDATE_URL)
-sparql_writer.setReturnFormat(JSON)
-sparql_writer.method = POST
-
-MARKETPLACE = Namespace("http://dev.data-marketplace.gov.uk/")
-DATASET = Namespace(MARKETPLACE["dataset/"])
-catalogue_graph = MARKETPLACE["graph/catalogue"]
-
-PREFIX = """
-PREFIX adms: <https://www.w3.org/ns/adms#>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX text: <http://jena.apache.org/text#>
-PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX cddo: <http://marketplace.cddo.gov.uk/asset/>
-PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-PREFIX uk_cross_government_metadata_exchange_model: <https://w3id.org/co-cddo/uk-cross-government-metadata-exchange-model/>
-"""
-
-
-def add_entry(ds_uri_slug, name, description):
-    query = f"""
-    INSERT DATA {{
-        GRAPH <{catalogue_graph}> {{
-            <{DATASET[ds_uri_slug]}> <{DCTERMS["title"]}> "{name}"
-        }}
-    }}
-    """
-    sparql_writer.setQuery(query)
-    ret = sparql_writer.queryAndConvert()
-    return ret
-
-
-sparql_reader = SPARQLWrapper(config.QUERY_URL)
-sparql_reader.setReturnFormat(JSON)
-
-
-def mediatypes_of_dataset(identifier: str):
-    query = f"""{PREFIX}
-    SELECT ?mediaType
-    WHERE {{
-        ?s dct:identifier "{identifier}" ;
-           dcat:distribution ?distribution .
-        BIND(URI(STR(?distribution)) AS ?dist)
-        ?dist dcat:mediaType ?mediaType .
-    }}"""
-
-    sparql_reader.setQuery(query)
-    results = sparql_reader.queryAndConvert()["results"]["bindings"]
-    result_dicts = [utils.search_query_result_to_dict(r) for r in results]
-    media_types = [r["mediaType"] for r in result_dicts]
-    return media_types
-
-
-def distribution_detail(distribution: str):
-    query = f"""{PREFIX}
-    SELECT ?title ?modified ?mediaType
-    WHERE {{
-        <{distribution}> dct:title ?title;
-                         dct:modified ?modified ;
-                         dcat:mediaType ?mediaType .
-    }}
-    """
-
-    sparql_reader.setQuery(query)
-    results = sparql_reader.queryAndConvert()["results"]["bindings"]
-    result_dict = [utils.search_query_result_to_dict(r) for r in results]
-    assert len(result_dict) == 1
-    return m.DistributionSummary.model_validate(result_dict[0])
+from . import sparql
 
 
 def search(q: str = ""):
@@ -97,101 +9,23 @@ def search(q: str = ""):
 
     # TODO What else do we need to do to sanitise the query string?
     q = utils.sanitise_search_query(q)
-
-    query = f"""{PREFIX}
-    SELECT ?identifier ?type ?title ?description ?organisation 
-            ?catalogueCreated ?catalogueModified ?created ?issued ?modified 
-            ?summary ?serviceType 
-            (GROUP_CONCAT(DISTINCT(?creators); separator='|') AS ?creator)
-    WHERE {{
-        ?s text:query "{q}" ;
-            dct:identifier ?identifier ;
-            a ?type ;
-            dct:title ?title ;
-    	    dct:description ?description ;
-            dct:publisher ?organisation ;
-            cddo:created ?catalogueCreated ;
-            cddo:modified ?catalogueModified .
-        OPTIONAL {{ ?s dct:creator ?creators }} .
-      	OPTIONAL {{ ?s dct:created ?created }} .
-      	OPTIONAL {{ ?s dct:issued ?issued }} .
-      	OPTIONAL {{ ?s dct:modified ?modified }} .
-      	OPTIONAL {{ ?s rdfs:comment ?summary }} .
-        OPTIONAL {{ ?s dct:type ?serviceType }} .
-    }}
-    GROUP BY ?identifier ?type ?title ?description ?organisation 
-            ?catalogueCreated ?catalogueModified ?created ?issued ?modified 
-            ?summary ?serviceType
-    """
-
-    sparql_reader.setQuery(query)
-    result = sparql_reader.queryAndConvert()["results"]["bindings"]
-
-    result_dicts = [utils.search_query_result_to_dict(r) for r in result]
-
-    for r in result_dicts:
-        if r["type"] == "Dataset":
-            r["mediaType"] = mediatypes_of_dataset(r["identifier"])
-
+    query_results = sparql.run_query("asset_search.sparql", q=q)
+    result_dicts = sparql.aggregate_query_results_by_key(query_results, group_key="identifier")
+    result_dicts = [utils.enrich_query_result_dict(r) for r in result_dicts]
     result_dicts = [utils.munge_asset_summary_response(r) for r in result_dicts]
+
     return result_dicts
 
 
+def fetch_distribution_details(distribution_ids):
+    distribution_ids = [f"<{i}>" for i in distribution_ids]
+    results = sparql.run_query("distribution_detail.sparql", distribution=distribution_ids)
+    return sparql.aggregate_query_results_by_key(results, group_key="distribution")
+
 def asset_detail(asset_id: str):
-    query = f"""{PREFIX}
-SELECT  ?updateFrequency ?endpointDescription ?endpointURL ?serviceStatus ?serviceType ?accessRights
-?contactName ?contactEmail ?contactAddress ?contactTelephone ?created ?description ?issued
-?licence ?modified ?organisation ?securityClassification ?summary ?title ?type ?catalogueCreated ?catalogueModified
-(GROUP_CONCAT(DISTINCT(?creators); separator='|') AS ?creator)
-(GROUP_CONCAT(DISTINCT(?keywords); separator='|') AS ?keyword)
-(GROUP_CONCAT(DISTINCT(?alternativeTitles); separator='|') AS ?alternativeTitle)
-(GROUP_CONCAT(DISTINCT(?relatedResources); separator='|') AS ?relatedResource)
-(GROUP_CONCAT(DISTINCT(?themes); separator='|') AS ?theme)
-(GROUP_CONCAT(DISTINCT(?servesDatas); separator='|') AS ?servesData)
-(GROUP_CONCAT(DISTINCT(?distribution); separator='|') AS ?distributions)
-WHERE {{
-?s dct:identifier "{asset_id}" ;
-   dcat:contactPoint ?contact ;
-   dct:description ?description ;
-   dct:license ?licence ;
-   dct:publisher ?organisation ;
-   uk_cross_government_metadata_exchange_model:securityClassification ?securityClassification ;
-   dct:title ?title ;
-   a ?type;
-   dcat:version ?version ;
-   cddo:created ?catalogueCreated ;
-   cddo:modified ?catalogueModified .
-  OPTIONAL {{ ?s dct:accrualPeriodicity ?updateFrequency }} .
-  OPTIONAL {{ ?s dcat:distribution ?distribution }} .
-  OPTIONAL {{ ?s dcat:endpointDescription ?endpointDescription }}.
-  OPTIONAL {{ ?s dcat:endpointURL ?endpointURL }}.
-  OPTIONAL {{ ?s dcat:servesData ?servesDatas }} .
-  OPTIONAL {{ ?s adms:status ?serviceStatus }} .
-  OPTIONAL {{ ?s dct:type ?serviceType }} .
-  OPTIONAL {{ ?s dct:accessRights ?accessRights }} .
-  OPTIONAL {{ ?s dct:created ?created }} .
-  OPTIONAL {{ ?s dct:issued ?issued }} .
-  OPTIONAL {{ ?s dct:modified ?modified }} .
-  OPTIONAL {{ ?s rdfs:comment ?summary }} .
-  OPTIONAL {{ ?s dct:creator ?creators }} .
-  OPTIONAL {{ ?s dcat:keyword ?keywords }} .
-  OPTIONAL {{ ?s dct:alternative ?alternativeTitles }} .
-  OPTIONAL {{ ?s dct:relation ?relatedResources }} .
-  OPTIONAL {{ ?s dcat:theme ?themes }} .
-
-  ?contact vcard:fn ?contactName ;
-           vcard:hasEmail ?contactEmail.
-  OPTIONAL {{?contact vcard:hasTelephone ?contactTelephone}}
-  OPTIONAL {{?contact vcard:hasAddress ?contactAddress}}
-}}
-GROUP BY ?updateFrequency ?endpointDescription ?endpointURL ?serviceStatus ?serviceType ?accessRights
-?contactName ?contactEmail ?contactAddress ?contactTelephone ?created ?description ?issued
-?licence ?modified ?organisation ?securityClassification ?summary ?title ?type ?catalogueCreated ?catalogueModified
-    """
-    sparql_reader.setQuery(query)
-    result = sparql_reader.queryAndConvert()["results"]["bindings"]
-
-    result_dicts = [utils.search_query_result_to_dict(r) for r in result]
+    query_results = sparql.run_query("asset_detail.sparql", asset_id=asset_id)
+    asset_result_dicts = sparql.aggregate_query_results_by_key(query_results, group_key="resourceUri")
+    result_dicts = [utils.enrich_query_result_dict(r) for r in asset_result_dicts]
     assert len(result_dicts) == 1
     asset = result_dicts[0]
 
@@ -207,19 +41,8 @@ GROUP BY ?updateFrequency ?endpointDescription ?endpointURL ?serviceStatus ?serv
     asset["contactPoint"] = m.ContactPoint.model_validate(contactPoint)
 
     if asset["type"] == m.assetType.dataset:
-        distributions = [distribution_detail(d) for d in asset["distributions"]]
-        asset["distributions"] = distributions
-
+        distributions = [utils.remove_keys(r, ["distribution"]) for r in
+                         fetch_distribution_details(asset["distribution"])]
+        asset["distributions"] = [m.DistributionSummary.model_validate(d)
+                                  for d in distributions]
     return asset
-
-
-def list_datasets():
-    query = f"""
-    SELECT * WHERE {{
-        GRAPH <{catalogue_graph}> {{
-            ?s ?p ?o .
-        }}
-    }}
-    """
-    sparql_reader.setQuery(query)
-    return sparql_reader.queryAndConvert()

--- a/api/app/sparql.py
+++ b/api/app/sparql.py
@@ -1,0 +1,63 @@
+from SPARQLWrapper import SPARQLWrapper, JSON
+from datetime import datetime
+from . import config
+from string import Template
+from itertools import groupby
+from rdflib.namespace import XSD
+
+
+sparql_reader = SPARQLWrapper(config.QUERY_URL)
+
+sparql_reader.setReturnFormat(JSON)
+
+
+def _prep_query(query_file_name, bindings):
+    for k, v in bindings.items():
+        if isinstance(v, list):
+            bindings[k] = " ".join(v)
+    with open(f"queries/{query_file_name}", "r") as f:
+        template = Template(f.read())
+    return template.substitute(bindings)
+
+def run_query(query_file_name, **bindings):
+    q = _prep_query(query_file_name, bindings)
+    sparql_reader.setQuery(q)
+    return sparql_reader.queryAndConvert()["results"]["bindings"]
+
+def _query_result_to_dict(result):
+    d = {}
+    for k, v in result.items():
+        if v.get("datatype") == str(XSD["date"]):
+            d[k] = datetime.fromisoformat(v["value"])
+        else:
+            d[k] = v["value"]
+    return d
+
+
+def _aggregate_results(results):
+    """Assuming all results relate to a single item, aggregate them to include a list of values for
+    any key with multiple values"""
+    result_dicts = [_query_result_to_dict(r) for r in results]
+    match len(result_dicts):
+        case 0:
+            return {}
+        case 1:
+            return result_dicts[0]
+        case _:
+            out = {}
+            for r in result_dicts:
+                for k, v in r.items():
+                    if k not in out:
+                        out[k] = v
+                    elif out[k] != v:
+                        if not isinstance(out[k], set):
+                            out[k] = {out[k]}
+                        out[k].add(v)
+            return out
+
+
+def aggregate_query_results_by_key(results, group_key="resourceUri"):
+    """Groups the result by given key and aggregates the groups into a single dictionary for each"""
+    get_uri = lambda result: result[group_key]["value"]
+    return [_aggregate_results(results_for_resource)
+            for _, results_for_resource in groupby(results, get_uri)]

--- a/api/queries/asset_detail.sparql
+++ b/api/queries/asset_detail.sparql
@@ -1,0 +1,47 @@
+PREFIX adms: <https://www.w3.org/ns/adms#>
+PREFIX cddo: <http://marketplace.cddo.gov.uk/asset/>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX uk_cross_government_metadata_exchange_model: <https://w3id.org/co-cddo/uk-cross-government-metadata-exchange-model/>
+
+SELECT ?resourceUri ?updateFrequency ?endpointDescription ?endpointURL ?serviceStatus ?serviceType ?accessRights
+?contactName ?contactEmail ?contactAddress ?contactTelephone ?created ?description ?issued
+?licence ?modified ?organisation ?securityClassification ?summary ?title ?type ?catalogueCreated ?catalogueModified ?creator ?keyword ?alternativeTitle ?relatedResource ?theme ?servesData ?distribution
+WHERE {{
+?resourceUri dct:identifier "$asset_id" ;
+   dcat:contactPoint ?contact ;
+   dct:description ?description ;
+   dct:license ?licence ;
+   dct:publisher ?organisation ;
+   uk_cross_government_metadata_exchange_model:securityClassification ?securityClassification ;
+   dct:title ?title ;
+   a ?typeURI;
+   dcat:version ?version ;
+   cddo:created ?catalogueCreated ;
+   cddo:modified ?catalogueModified .
+  ?typeURI rdfs:label ?type .
+  OPTIONAL {{ ?resourceUri dct:accrualPeriodicity ?updateFrequency }} .
+  OPTIONAL {{ ?resourceUri dcat:distribution ?distribution }}.
+  OPTIONAL {{ ?resourceUri dcat:endpointDescription ?endpointDescription }}.
+  OPTIONAL {{ ?resourceUri dcat:endpointURL ?endpointURL }}.
+  OPTIONAL {{ ?resourceUri dcat:servesData ?servesData }} .
+  OPTIONAL {{ ?resourceUri adms:status ?serviceStatus }} .
+  OPTIONAL {{ ?resourceUri dct:type ?serviceType }} .
+  OPTIONAL {{ ?resourceUri dct:accessRights ?accessRights }} .
+  OPTIONAL {{ ?resourceUri dct:created ?created }} .
+  OPTIONAL {{ ?resourceUri dct:issued ?issued }} .
+  OPTIONAL {{ ?resourceUri dct:modified ?modified }} .
+  OPTIONAL {{ ?resourceUri rdfs:comment ?summary }} .
+  OPTIONAL {{ ?resourceUri dct:creator ?creator }} .
+  OPTIONAL {{ ?resourceUri dcat:keyword ?keyword }} .
+  OPTIONAL {{ ?resourceUri dct:alternative ?alternativeTitle }} .
+  OPTIONAL {{ ?resourceUri dct:relation ?relatedResource }} .
+  OPTIONAL {{ ?resourceUri dcat:theme ?theme }} .
+
+  ?contact vcard:fn ?contactName ;
+           vcard:hasEmail ?contactEmail.
+  OPTIONAL {{?contact vcard:hasTelephone ?contactTelephone}}
+  OPTIONAL {{?contact vcard:hasAddress ?contactAddress}}
+}}

--- a/api/queries/asset_search.sparql
+++ b/api/queries/asset_search.sparql
@@ -1,0 +1,30 @@
+PREFIX text: <http://jena.apache.org/text#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cddo: <http://marketplace.cddo.gov.uk/asset/>
+
+SELECT ?identifier ?type ?title ?description ?organisation 
+        ?catalogueCreated ?catalogueModified ?created ?issued ?modified 
+        ?summary ?serviceType ?creator ?mediaType
+WHERE {{
+    ?s text:query "$q" ;
+        dct:identifier ?identifier ;
+        a ?typeURI ;
+        dct:title ?title ;
+        dct:description ?description ;
+        dct:publisher ?organisation ;
+        cddo:created ?catalogueCreated ;
+        cddo:modified ?catalogueModified ;
+        .
+    ?typeURI rdfs:label ?type .
+    OPTIONAL {{ ?s dcat:distribution ?distribution }
+              { ?distribution dcat:mediaType ?mediaTypeUri }
+              { ?mediaTypeUri rdfs:label ?mediaType }} .
+    OPTIONAL {{ ?s dct:creator ?creator }} .
+    OPTIONAL {{ ?s dct:created ?created }} .
+    OPTIONAL {{ ?s dct:issued ?issued }} .
+    OPTIONAL {{ ?s dct:modified ?modified }} .
+    OPTIONAL {{ ?s rdfs:comment ?summary }} .
+    OPTIONAL {{ ?s dct:type ?serviceType }} .
+}}

--- a/api/queries/distribution_detail.sparql
+++ b/api/queries/distribution_detail.sparql
@@ -1,0 +1,12 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?distribution ?title ?modified ?mediaType
+WHERE {{
+    VALUES ?distribution { $distribution }
+    ?distribution dct:title ?title ;
+                  dct:modified ?modified ;
+                  dcat:mediaType ?mediaTypeUri .
+    ?mediaTypeUri rdfs:label ?mediaType .
+}}

--- a/fuseki/data/dwp-address-lookup.ttl
+++ b/fuseki/data/dwp-address-lookup.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix cddo: <http://marketplace.cddo.gov.uk/asset/> .
 
-cddo:fcbc4d3f-0c05-4857-b0e3-eeec6bfea3a1 a "dcat:DataService"^^xsd:anyURI ;
+cddo:fcbc4d3f-0c05-4857-b0e3-eeec6bfea3a1 a dcat:DataService ;
     dct:identifier "fcbc4d3f-0c05-4857-b0e3-eeec6bfea3a1" ;
     dct:accessRights "INTERNAL" ;
     dct:creator "department-for-work-pensions" ;
@@ -61,10 +61,10 @@ This endpoint provides an address matching function. It will take an unstructure
     dcat:endpointDescription "https://engineering.dwp.gov.uk/apis/docs"^^xsd:anyURI ;
     dcat:keyword "Address Search",
         "UPRN" ;
-    dcat:servesData "https://www.data.gov.uk/dataset/03d48dba-529b-4bd5-93a5-6d41d1b20ff9/national-address-gazetteer"^^xsd:anyURI,
-        "https://www.data.gov.uk/dataset/2dfb82b4-741a-4b93-807e-11abb4bb0875/os-postcodes-data"^^xsd:anyURI,
-        "https://www.data.gov.uk/dataset/92b32629-8ad4-43cb-9952-7d104971fa12/one-scotland-gazetteer"^^xsd:anyURI ;
-    dcat:theme "https://www.data.gov.uk/search?filters%5Btopic%5D=Mapping"^^xsd:anyURI ;
+    dcat:servesData <https://www.data.gov.uk/dataset/03d48dba-529b-4bd5-93a5-6d41d1b20ff9/national-address-gazetteer>,
+        <https://www.data.gov.uk/dataset/2dfb82b4-741a-4b93-807e-11abb4bb0875/os-postcodes-data>,
+        <https://www.data.gov.uk/dataset/92b32629-8ad4-43cb-9952-7d104971fa12/one-scotland-gazetteer> ;
+    dcat:theme <https://www.data.gov.uk/search?filters%5Btopic%5D=Mapping> ;
     dcat:version "2.0.0" ;
     uk_cross_government_metadata_exchange_model:securityClassification "OFFICIAL" ;
     adms:status "LIVE" .

--- a/fuseki/data/os-postcodes-csv-distribution.ttl
+++ b/fuseki/data/os-postcodes-csv-distribution.ttl
@@ -1,8 +1,9 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix text: <https://www.iana.org/assignments/media-types/text/> .
 
-<https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=CSV&redirect> a "dcat:Distribution"^^xsd:anyURI ;
+<https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=CSV&redirect> a dcat:Distribution;
     dct:accessRights "OPEN" ;
     dct:description "Free and open postcode location data. Can be used for geographical analysis simple route planning asset management and much more." ;
     dct:issued "2023-02-01"^^xsd:date ;
@@ -12,5 +13,4 @@
     dcat:accessService "retirement-bereavement-care-address-lookup-location-service-v2.0.0"^^xsd:anyURI ;
     dcat:byteSize 14330000 ;
     dcat:downloadURL "https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=CSV&redirect"^^xsd:anyURI ;
-    dcat:mediaType "text/csv"^^xsd:anyURI .
-
+    dcat:mediaType text:csv .

--- a/fuseki/data/os-postcodes-datset.ttl
+++ b/fuseki/data/os-postcodes-datset.ttl
@@ -6,7 +6,7 @@
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://www.data.gov.uk/dataset/2dfb82b4-741a-4b93-807e-11abb4bb0875/os-postcodes-data> a "dcat:Dataset"^^xsd:anyURI ;
+<https://www.data.gov.uk/dataset/2dfb82b4-741a-4b93-807e-11abb4bb0875/os-postcodes-data> a dcat:Dataset ;
     dct:identifier "2dfb82b4-741a-4b93-807e-11abb4bb0875" ;
     dct:accessRights "OPEN" ;
     dct:accrualPeriodicity freq:quarterly ;
@@ -23,10 +23,10 @@
     dcat:contactPoint [ a vcard:Kind ;
             vcard:fn "Ordnance Survey Customer Service Centre" ;
             vcard:hasEmail "customerservices@os.uk" ] ;
-    dcat:distribution "https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=CSV&redirect"^^xsd:anyURI,
-        "https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=GeoPackage&redirect"^^xsd:anyURI ;
+    dcat:distribution <https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=CSV&redirect>,
+        <https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=GeoPackage&redirect> ;
     dcat:keyword "Address", "Postcode" ;
-    dcat:theme "https://www.data.gov.uk/search?filters%5Btopic%5D=Mapping"^^xsd:anyURI ;
+    dcat:theme <https://www.data.gov.uk/search?filters%5Btopic%5D=Mapping> ;
     dcat:version "2023-02" ;
     uk_cross_government_metadata_exchange_model:securityClassification "OFFICIAL" .
 

--- a/fuseki/data/os-postcodes-geopackage-distribution.ttl
+++ b/fuseki/data/os-postcodes-geopackage-distribution.ttl
@@ -1,8 +1,9 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix application: <https://www.iana.org/assignments/media-types/application/> .
 
-<https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=GeoPackage&redirect> a "dcat:Distribution"^^xsd:anyURI ;
+<https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=GeoPackage&redirect> a dcat:Distribution;
     dct:accessRights "OPEN" ;
     dct:description "Free and open postcode location data. Can be used for geographical analysis, simple route planning, asset management and much more." ;
     dct:issued "2023-02-01"^^xsd:date ;
@@ -12,5 +13,5 @@
     dcat:accessService "retirement-bereavement-care-address-lookup-location-service-v2.0.0"^^xsd:anyURI ;
     dcat:byteSize 55410000 ;
     dcat:downloadURL "https://api.os.uk/downloads/v1/products/CodePointOpen/downloads?area=GB&format=CSV&redirect"^^xsd:anyURI ;
-    dcat:mediaType "application/geopackage+sqlite3"^^xsd:anyURI .
+    dcat:mediaType <application:geopackage+sqlite3> .
 

--- a/fuseki/data/vocab.ttl
+++ b/fuseki/data/vocab.ttl
@@ -1,0 +1,12 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix application: <https://www.iana.org/assignments/media-types/application/> .
+@prefix text: <https://www.iana.org/assignments/media-types/text/> .
+
+dcat:Distribution rdfs:label "Distribution"@en .
+dcat:Dataset rdfs:label "Dataset"@en .
+dcat:DataService rdfs:label "DataService"@en .
+
+<application:geopackage+sqlite3> rdfs:label "GeoPackage" .
+<application:vnd.ms-excel> rdfs:label "XLS".
+text:csv rdfs:label "CSV" .


### PR DESCRIPTION
* Extract sparql queries into their own files
* Add sparql module to run queries and reformat the responses
* Get media type as part of distribution query
* Query for all distributions in an assset instead of one at a time
* Store asset types, media types, and other URI values as URIs instead of strings in the data files
* Add a vocab file that is used to look up labels for asset and media types instead of hard-coding these
* Store distribution URIs as URIs so we can associate data with them and query for their attributes without formatting a string