### PR TITLE
Kj/organisation list

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, Body, Query, HTTPException
 from fastapi.responses import JSONResponse
 from . import model as m
 from . import db
+from . import utils
 
 app = FastAPI(title="CDDO Data Marketplace API", version="0.1.0")
 
@@ -17,7 +18,10 @@ app = FastAPI(title="CDDO Data Marketplace API", version="0.1.0")
 
 @app.get("/organisations")
 async def list_organisations() -> List[m.Organisation]:
-    return [m.Organisation.parse_obj(o) for o in m.organisations.values()]
+    return sorted(
+        [m.Organisation.model_validate(utils.orgs[o]) for o in utils.MVP_ORGS],
+        key=lambda o: o.title,
+    )
 
 
 # TODO: add theme query param

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -18,10 +18,12 @@ class assetType(str, Enum):
 
 
 class Organisation(BaseModel):
-    title: str
     id: str
-    acronym: str
-    homepage: AnyUrl
+    title: str
+    abbreviation: str | None
+    slug: str
+    format: str
+    web_url: AnyUrl
 
 
 class organisationID(str, Enum):

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -108,6 +108,7 @@ class BaseAsset(BaseAssetSummary):
     accessRights: rightsStatement | None = None
     alternativeTitle: List[str] | None = []
     contactPoint: ContactPoint
+    description: str
     issued: datetime | None = None
     keyword: List[str] | None = []
     licence: AnyUrl | None = (

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -1,38 +1,85 @@
 from datetime import datetime
+import requests
 
 from . import model as m
 
-organisations = {
-    "department-for-work-pensions": {
-        "id": "department-for-work-pensions",
-        "title": "Department for Work & Pensions",
-        "acronym": "DWP",
-        "homepage": "https://www.gov.uk/government/organisations/department-for-work-pensions",
-    },
-    "food-standards-agency": {
-        "id": "food-standards-agency",
-        "title": "Food Standards Agency",
-        "acronym": "FSA",
-        "homepage": "https://www.food.gov.uk/",
-    },
-    "nhs-digital": {
-        "id": "nhs-digital",
-        "title": "NHS Digital",
-        "acronym": "NHS Digital",
-        "homepage": "https://digital.nhs.uk/",
-    },
-    "ordnance-survey": {
-        "id": "ordnance-survey",
-        "title": "Ordnance Survey",
-        "acronym": "OS",
-        "homepage": "https://www.gov.uk/government/organisations/ordnance-survey",
-    },
-}
+MVP_ORGS = [
+    "attorney-generals-office",
+    "cabinet-office",
+    "competition-and-markets-authority",
+    "crown-prosecution-service",
+    "department-for-business-and-trade",
+    "department-for-culture-media-and-sport",
+    "department-for-education",
+    "department-for-energy-security-and-net-zero",
+    "department-for-environment-food-rural-affairs",
+    "department-for-levelling-up-housing-and-communities",
+    "department-for-science-innovation-and-technology",
+    "department-for-transport",
+    "department-for-work-pensions",
+    "department-of-health-and-social-care",
+    "food-standards-agency",
+    "foreign-commonwealth-development-office",
+    "forestry-commission",
+    "government-actuarys-department",
+    "government-legal-department",
+    "land-registry",
+    "hm-revenue-customs",
+    "hm-treasury",
+    "home-office",
+    "ministry-of-defence",
+    "ministry-of-justice",
+    "national-crime-agency",
+    "northern-ireland-office",
+    "ns-i",
+    "office-of-rail-and-road",
+    "office-of-the-advocate-general-for-scotland",
+    "the-office-of-the-leader-of-the-house-of-commons",
+    "office-of-the-leader-of-the-house-of-lords",
+    "office-of-the-secretary-of-state-for-scotland",
+    "office-of-the-secretary-of-state-for-wales",
+    "ofgem",
+    "ofqual",
+    "ofsted",
+    "prime-ministers-office-10-downing-street",
+    "serious-fraud-office",
+    "supreme-court-of-the-united-kingdom",
+    "charity-commission",
+    "the-national-archives",
+    "the-water-services-regulation-authority",
+    "uk-export-finance",
+    "uk-statistics-authority",
+]
+
+
+def initialise_organisations():
+    def parse_orgs(org_results):
+        return {
+            o["details"]["slug"]: {
+                "id": o["id"],
+                "title": o["title"],
+                "abbreviation": o["details"]["abbreviation"],
+                "slug": o["details"]["slug"],
+                "format": o["format"],
+                "web_url": o["web_url"],
+            }
+            for o in org_results
+        }
+
+    response = requests.get("https://www.gov.uk/api/organisations").json()
+    orgs = parse_orgs(response["results"])
+    while response.get("next_page_url", None):
+        response = requests.get(response["next_page_url"]).json()
+        orgs = {**orgs, **parse_orgs(response["results"])}
+    return orgs
+
+
+orgs = initialise_organisations()
 
 
 def lookup_organisation(org_id: m.organisationID) -> m.Organisation:
     try:
-        org_data = organisations[org_id]
+        org_data = orgs[org_id]
     except:
         raise ValueError("Organisation does not exist")
     return m.Organisation.model_validate(org_data)

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -76,6 +76,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "certifi"
+version = "2023.7.22"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
+]
+
+[[package]]
 name = "cfgv"
 version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
@@ -84,6 +95,90 @@ python-versions = ">=3.6.1"
 files = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.2.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win32.whl", hash = "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win32.whl", hash = "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win32.whl", hash = "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win32.whl", hash = "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win32.whl", hash = "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80"},
+    {file = "charset_normalizer-3.2.0-py3-none-any.whl", hash = "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6"},
 ]
 
 [[package]]
@@ -538,6 +633,23 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pyjwt"
+version = "2.8.0"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
+    {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
 name = "pyparsing"
 version = "3.1.0"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -650,6 +762,27 @@ lxml = ["lxml (>=4.3.0,<5.0.0)"]
 networkx = ["networkx (>=2.0.0,<3.0.0)"]
 
 [[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
 name = "setuptools"
 version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -745,6 +878,23 @@ files = [
     {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
     {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
+
+[[package]]
+name = "urllib3"
+version = "2.0.4"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
+    {file = "urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -951,4 +1101,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "62ba1a765a1eebab4044efaa68099e53042eb82a156b4f161ed8377e1c3be3e9"
+content-hash = "18abf4912fa146fedf6fcb92cb21e60d8673fdc163176740990246ada2866df2"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -16,11 +16,13 @@ python-dotenv = "^1.0.0"
 pydantic = {extras = ["email"], version = "^2.1.1"}
 faker = "^19.2.0"
 sparql-burger = "^1.0.2"
+requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"
 pre-commit = "^3.3.3"
 polyfactory = "^2.7.0"
+pyjwt = "^2.8.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/api/queries/asset_detail.sparql
+++ b/api/queries/asset_detail.sparql
@@ -22,7 +22,8 @@ WHERE {{
    cddo:created ?catalogueCreated ;
    cddo:modified ?catalogueModified .
   ?typeURI rdfs:label ?type .
-  OPTIONAL {{ ?resourceUri dct:accrualPeriodicity ?updateFrequency }} .
+  OPTIONAL {{ ?resourceUri dct:accrualPeriodicity ?freq }
+            { ?freq rdfs:label ?updateFrequency }} .
   OPTIONAL {{ ?resourceUri dcat:distribution ?distribution }}.
   OPTIONAL {{ ?resourceUri dcat:endpointDescription ?endpointDescription }}.
   OPTIONAL {{ ?resourceUri dcat:endpointURL ?endpointURL }}.

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,6 +4,85 @@ annotated-types==0.5.0 ; python_version >= "3.11" and python_version < "4.0" \
 anyio==3.7.1 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780 \
     --hash=sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5
+certifi==2023.7.22 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
+charset-normalizer==3.2.0 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96 \
+    --hash=sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c \
+    --hash=sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710 \
+    --hash=sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706 \
+    --hash=sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020 \
+    --hash=sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252 \
+    --hash=sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad \
+    --hash=sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329 \
+    --hash=sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a \
+    --hash=sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f \
+    --hash=sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6 \
+    --hash=sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4 \
+    --hash=sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a \
+    --hash=sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46 \
+    --hash=sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2 \
+    --hash=sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23 \
+    --hash=sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace \
+    --hash=sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd \
+    --hash=sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982 \
+    --hash=sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10 \
+    --hash=sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2 \
+    --hash=sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea \
+    --hash=sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09 \
+    --hash=sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5 \
+    --hash=sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149 \
+    --hash=sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489 \
+    --hash=sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9 \
+    --hash=sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80 \
+    --hash=sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592 \
+    --hash=sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3 \
+    --hash=sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6 \
+    --hash=sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed \
+    --hash=sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c \
+    --hash=sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200 \
+    --hash=sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a \
+    --hash=sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e \
+    --hash=sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d \
+    --hash=sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6 \
+    --hash=sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623 \
+    --hash=sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669 \
+    --hash=sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3 \
+    --hash=sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa \
+    --hash=sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9 \
+    --hash=sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2 \
+    --hash=sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f \
+    --hash=sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1 \
+    --hash=sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4 \
+    --hash=sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a \
+    --hash=sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8 \
+    --hash=sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3 \
+    --hash=sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029 \
+    --hash=sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f \
+    --hash=sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959 \
+    --hash=sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22 \
+    --hash=sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7 \
+    --hash=sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952 \
+    --hash=sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346 \
+    --hash=sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e \
+    --hash=sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d \
+    --hash=sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299 \
+    --hash=sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd \
+    --hash=sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a \
+    --hash=sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3 \
+    --hash=sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037 \
+    --hash=sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94 \
+    --hash=sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c \
+    --hash=sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858 \
+    --hash=sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a \
+    --hash=sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449 \
+    --hash=sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c \
+    --hash=sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918 \
+    --hash=sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1 \
+    --hash=sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c \
+    --hash=sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac \
+    --hash=sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa
 click==8.1.6 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd \
     --hash=sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5
@@ -228,6 +307,9 @@ pyyaml==6.0.1 ; python_version >= "3.11" and python_version < "4.0" \
 rdflib==6.3.2 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:36b4e74a32aa1e4fa7b8719876fb192f19ecd45ff932ea5ebbd2e417a0247e63 \
     --hash=sha256:72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0
+requests==2.31.0 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
 six==1.16.0 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -246,6 +328,9 @@ starlette==0.27.0 ; python_version >= "3.11" and python_version < "4.0" \
 typing-extensions==4.7.1 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
+urllib3==2.0.4 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11 \
+    --hash=sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4
 uvicorn[standard]==0.23.1 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:1d55d46b83ee4ce82b4e82f621f2050adb3eb7b5481c13f9af1744951cae2f1f \
     --hash=sha256:da9b0c8443b2d7ee9db00a345f1eee6db7317432c9d4400f5049cc8d358383be

--- a/fuseki/data/updateFrequency.ttl
+++ b/fuseki/data/updateFrequency.ttl
@@ -1,0 +1,179 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ns0: <http://purl.org/dc/dcam/> .
+
+<http://purl.org/cld/freq/>
+  dc:title "The Collection Description Frequency Namespace"@en ;
+  dc:creator [ rdfs:label "Dublin Core Collection Description Task Group" ] ;
+  dc:modified "2013-05-10"^^dc:W3CDTF .
+
+<http://purl.org/cld/freq/triennial>
+  a skos:Concept ;
+  rdfs:label "Triennial"@en ;
+  skos:prefLabel "Triennial"@en ;
+  rdfs:comment "The event occurs every three years."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/biennial>
+  a skos:Concept ;
+  rdfs:label "Biennial"@en ;
+  skos:prefLabel "Biennial"@en ;
+  rdfs:comment "The event occurs every two years."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/annual>
+  a skos:Concept ;
+  rdfs:label "Annual"@en ;
+  skos:prefLabel "Annual"@en ;
+  rdfs:comment "The event occurs once a year."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/semiannual>
+  a skos:Concept ;
+  rdfs:label "Semiannual"@en ;
+  skos:prefLabel "Semiannual"@en ;
+  rdfs:comment "The event occurs twice a year."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/threeTimesAYear>
+  a skos:Concept ;
+  rdfs:label "Three times a year"@en ;
+  skos:prefLabel "Three times a year"@en ;
+  rdfs:comment "The event occurs three times a year."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/quarterly>
+  a skos:Concept ;
+  rdfs:label "Quarterly"@en ;
+  skos:prefLabel "Quarterly"@en ;
+  rdfs:comment "The event occurs every three months."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/bimonthly>
+  a skos:Concept ;
+  rdfs:label "Bimonthly"@en ;
+  skos:prefLabel "Bimonthly"@en ;
+  rdfs:comment "The event occurs every two months."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/monthly>
+  a skos:Concept ;
+  rdfs:label "Monthly"@en ;
+  skos:prefLabel "Monthly"@en ;
+  rdfs:comment "The event occurs once a month."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/semimonthly>
+  a skos:Concept ;
+  rdfs:label "Semimonthly"@en ;
+  skos:prefLabel "Semimonthly"@en ;
+  rdfs:comment "The event occurs twice a month."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/biweekly>
+  a skos:Concept ;
+  rdfs:label "Biweekly"@en ;
+  skos:prefLabel "Biweekly"@en ;
+  rdfs:comment "The event occurs every two weeks."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/threeTimesAMonth>
+  a skos:Concept ;
+  rdfs:label "Three times a month"@en ;
+  skos:prefLabel "Three times a month"@en ;
+  rdfs:comment "The event occurs three times a month."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/weekly>
+  a skos:Concept ;
+  rdfs:label "Weekly"@en ;
+  skos:prefLabel "Weekly"@en ;
+  rdfs:comment "The event occurs once a week."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/semiweekly>
+  a skos:Concept ;
+  rdfs:label "Semiweekly"@en ;
+  skos:prefLabel "Semiweekly"@en ;
+  rdfs:comment "The event occurs twice a week."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/threeTimesAWeek>
+  a skos:Concept ;
+  rdfs:label "Three times a week"@en ;
+  skos:prefLabel "Three times a week"@en ;
+  rdfs:comment "The event occurs three times a week."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/daily>
+  a skos:Concept ;
+  rdfs:label "Daily"@en ;
+  skos:prefLabel "Daily"@en ;
+  rdfs:comment "The event occurs once a day."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/continuous>
+  a skos:Concept ;
+  rdfs:label "Continuous"@en ;
+  skos:prefLabel "Continuous"@en ;
+  rdfs:comment "The event repeats without interruption."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+
+<http://purl.org/cld/freq/irregular>
+  a skos:Concept ;
+  rdfs:label "Irregular"@en ;
+  skos:prefLabel "Irregular"@en ;
+  rdfs:comment "The event occurs at uneven intervals."@en ;
+  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
+  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
+  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
+  ns0:memberOf <http://purl.org/cld/terms/Frequency> .


### PR DESCRIPTION
# Updates for DMBM-720
This PR fixes something that Alasdair noted in [DMBM-720](https://cddodatamarketplace.atlassian.net/jira/software/projects/DMBM/boards/6?selectedIssue=DMBM-720)

## Changes
- Added a function to grab & parse the organisations from the gov API, so every time the API starts up it always has an up-to-date list of organisations. Also updated the `Organisation` model slightly and added a temporary `MVP_ORGS` list to only return the [requested organisations](https://docs.google.com/spreadsheets/d/1K1Bzt2DUopTnnYzCCPRT-PriMq-ngzih78WLdFr_aaU/edit#gid=0) for the MVP.
- Added `description` to the `BaseAsset` model. I forgot to add this before, so no descriptions were being returned for the assets.
- Added `updateFrequency.ttl` based on what wee discussed on Slack. Also updated the `asset_detail` query to return the `rdfs:label` for the `updateFrequency`