### PR TITLE
Fuseki debug

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.1.1"
+version = "0.1.4"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,6 @@ services:
       # - fuseki_storage:/fuseki-base/databases
     ports:
       - 3030:3030
-    environment:
-      - ENABLE_UPDATE=true
-      - ENABLE_DATA_WRITE=true
-      - ENABLE_UPLOAD=true
     networks:
       - marketplace
       

--- a/fuseki/assembler.ttl
+++ b/fuseki/assembler.ttl
@@ -16,9 +16,9 @@
 <#service> rdf:type fuseki:Service ;
     fuseki:name              "ds" ;   # http://host:port/ds
     fuseki:serviceQuery      "sparql" ;    # SPARQL query service
-    #fuseki:serviceUpdate     "update" ;    # SPARQL update service
-    #fuseki:serviceUpload     "upload" ;    # Non-SPARQL upload service
-    #fuseki:serviceReadWriteGraphStore "data" ;     # SPARQL Graph store protocol
+    fuseki:serviceUpdate     "update" ;    # SPARQL update service
+    # fuseki:serviceUpload     "upload" ;    # Non-SPARQL upload service
+    fuseki:serviceReadWriteGraphStore "data" ;     # SPARQL Graph store protocol
     fuseki:serviceReadGraphStore    "data" ;     # SPARQL Graph store protocol (read only)
     fuseki:dataset           <#text> ;
 #    fuseki:dataset           <#tdb> ;


### PR DESCRIPTION
# Fuseki update endpoint
The deployed version of Fuseki doesn't seem to have the `/update` endpoint enabled correctly. There are lots of errors in the logs like:
```
2023-09-06T13:10:17.985+01:00 | 12:10:17 INFO Fuseki :: [52] POST http://c-dm-backend-fuseki:3030/ds/update
2023-09-06T13:10:17.986+01:00 | 12:10:17 INFO Fuseki :: [52] No Fuseki dispatch /ds/update
2023-09-06T13:10:19.544+01:00 | 12:10:19 INFO Fuseki :: [53] POST http://c-dm-backend-fuseki:3030/ds/update
2023-09-06T13:10:19.544+01:00 | 12:10:19 INFO Fuseki :: [53] No Fuseki dispatch /ds/update
2023-09-06T13:10:20.669+01:00 | 12:10:20 INFO Fuseki :: [54] POST http://c-dm-backend-fuseki:3030/ds/update
2023-09-06T13:10:20.669+01:00 | 12:10:20 INFO Fuseki :: [54] No Fuseki dispatch /ds/update
```

so I've tried hard-coding the update endpoint setup in the Dockerfile rather than using the ENV variables specified in the [fuseki docker](https://github.com/SemanticComputing/fuseki-docker) base image

Also updated the version in `pyproject.yaml` so this can be redeployed easily