### PR TITLE
Received requests

### DIFF
--- a/api/app/model.py
+++ b/api/app/model.py
@@ -328,6 +328,7 @@ class UpsertShareDataRequest(BaseModel):
 class ShareRequest(BaseModel):
     requestId: str
     assetTitle: str
+    requesterEmail: EmailStr
     requestingOrg: str
     status: Literal[
         "NOT STARTED",
@@ -340,7 +341,7 @@ class ShareRequest(BaseModel):
     ]
     received: datetime
     sharedata: ShareData
-    neededBy: date
+    neededBy: date | Literal["UNREQUESTED"]
 
 
 class CreateDatasetBody(CreateAssetBody, Dataset):

--- a/api/app/routers/manage_shares.py
+++ b/api/app/routers/manage_shares.py
@@ -14,7 +14,7 @@ from app.auth.utils import ops_user
 router = APIRouter(prefix="/manage-shares")
 
 
-def enrich_share_request(r) -> m.ShareRequest:
+def enrich_share_request(r: dict) -> m.ShareRequest:
     sharedata = m.ShareData.model_validate_json(r["sharedata"])
     neededBy = sharedata.steps["date"].value
     if not (neededBy["day"] and neededBy["month"] and neededBy["year"]):
@@ -25,6 +25,9 @@ def enrich_share_request(r) -> m.ShareRequest:
             month=int(neededBy["month"]),
             day=int(neededBy["day"]),
         )
+
+    requestingOrg = utils.lookup_organisation(r["requestingOrg"])
+    r["requestingOrg"] = requestingOrg.title
     r["neededBy"] = neededBy
     r["sharedata"] = sharedata
     return m.ShareRequest.model_validate(r)

--- a/api/queries/shares/get_by_id.sparql
+++ b/api/queries/shares/get_by_id.sparql
@@ -1,11 +1,12 @@
 PREFIX schema: <http://schema.org/>
 PREFIX adms: <https://www.w3.org/ns/adms#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?assetTitle ?assetPublisher ?requestingOrg ?status ?received ?sharedata 
+SELECT ?assetTitle ?assetPublisher ?requesterEmail ?requestingOrg ?status ?received ?sharedata 
 FROM cddo_graph:shares
 FROM cddo_graph:assets
 FROM cddo_graph:users
@@ -21,7 +22,8 @@ WHERE {
 			dct:publisher ?assetPublisher;
 			dct:title ?assetTitle .	
 
-	?user dct:identifier ?userId ;
-		  schema:memberOf ?requestingOrg .
+	?user	vcard:hasEmail ?requesterEmail
+			dct:identifier ?userId ;
+			schema:memberOf ?requestingOrg .
 
 }

--- a/api/queries/shares/get_by_id.sparql
+++ b/api/queries/shares/get_by_id.sparql
@@ -22,7 +22,7 @@ WHERE {
 			dct:publisher ?assetPublisher;
 			dct:title ?assetTitle .	
 
-	?user	vcard:hasEmail ?requesterEmail
+	?user	vcard:hasEmail ?requesterEmail ;
 			dct:identifier ?userId ;
 			schema:memberOf ?requestingOrg .
 

--- a/api/queries/shares/get_by_org.sparql
+++ b/api/queries/shares/get_by_org.sparql
@@ -1,11 +1,12 @@
 PREFIX schema: <http://schema.org/>
 PREFIX adms: <https://www.w3.org/ns/adms#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?requestId ?assetTitle ?requestingOrg ?status ?received ?sharedata 
+SELECT ?requestId ?assetTitle ?requesterEmail ?requestingOrg ?status ?received ?sharedata 
 FROM cddo_graph:shares
 FROM cddo_graph:assets
 FROM cddo_graph:users
@@ -22,6 +23,7 @@ WHERE {
 			cddo:user ?userId .
 
 	?user dct:identifier ?userId ;
+		  vcard:hasEmail ?requesterEmail ;
 		  schema:memberOf ?requestingOrg .
 
 	FILTER(?status NOT IN ("NOT STARTED", "IN PROGRESS"))

--- a/fuseki/data/os-postcodes-datset.ttl
+++ b/fuseki/data/os-postcodes-datset.ttl
@@ -27,7 +27,7 @@ cddo_asset:b3ae48af-c130-44ac-8341-5dead13c5427 a dcat:Dataset ;
     rdfs:comment "Free and open postcode location data. Can be used for geographical analysis simple route planning asset management and much more." ;
     dcat:contactPoint [ a vcard:Kind ;
             vcard:fn "Ordnance Survey Customer Service Centre" ;
-            vcard:hasEmail "customerservices@os.uk" ] ;
+            vcard:hasEmail "customerservices@os.gov.uk" ] ;
     dcat:distribution cddo_distribution:ac7ac094-0098-4849-97b4-f9f65b537651 ,
                       cddo_distribution:0e4773ea-2de6-4b27-98f4-63ff2f4d80a9 ;
     dcat:keyword "Address", "Postcode" ;


### PR DESCRIPTION
# Received requests bugfixes
Fixed a few bugs which should now mean that the Receive Requests API endpoints have got most of what's needed to power the UI.

## Changes
- Added `requesterEmail` to the `shares/get_by_id` and `get_by_org` queries. Also updated the Pydantic models to include email
- Updated the ShareRequest model to allow `UNREQUESTED` for the `neededBy` date.
- Return the requesting organisation's title instead of the slug.
- Update the `os-postcodes-datset.ttl` reference data to use a `.gov.uk` email address, because it was failing our recently-added validation