### PR TITLE
Complete your profile

### DIFF
--- a/api/app/db/user.py
+++ b/api/app/db/user.py
@@ -40,8 +40,8 @@ def edit_org(user_id, org):
     return res
 
 
-def complete_profile(user_id, org, role):
+def complete_profile(user_id, org, jobTitle):
     res = users_db.run_update(
-        "user/complete_profile", user_id=user_id, org=org, role=role
+        "user/complete_profile", user_id=user_id, org=org, jobTitle=jobTitle
     )
     return res

--- a/api/app/db/user.py
+++ b/api/app/db/user.py
@@ -1,11 +1,11 @@
 from app.db.sparql import users_db
+from app import model as m
 
 
-def new_user(user_id: str, user_email: str):
-    query_results = users_db.run_update(
-        "user/create", user_id=user_id, user_email=user_email
-    )
-    return query_results
+def new_user(user_id: str, user_email: str) -> m.User:
+    users_db.run_update("user/create", user_id=user_id, user_email=user_email)
+    user = get_by_id(user_id)
+    return user
 
 
 def list_users():
@@ -13,16 +13,23 @@ def list_users():
     return query_results
 
 
-def get_by_id(user_id: str) -> str | None:
+def get_by_id(user_id: str) -> m.User | None:
     query_results = users_db.run_query("user/get_by_id", user_id=user_id)
     assert len(query_results) <= 1, "Found multiple users with the same email address."
 
     if not query_results:
         return None
 
-    return query_results[0]
+    return m.User.model_validate(query_results[0])
 
 
 def edit_org(user_id, org):
     res = users_db.run_update("user/edit_org", user_id=user_id, org=org)
+    return res
+
+
+def complete_profile(user_id, org, role):
+    res = users_db.run_update(
+        "user/complete_profile", user_id=user_id, org=org, role=role
+    )
     return res

--- a/api/app/db/utils.py
+++ b/api/app/db/utils.py
@@ -69,3 +69,11 @@ def munge_asset_summary_response(result_dict):
     del r["description"]
 
     return r
+
+
+def enrich_user_org(user):
+    u = user.copy()
+    org = u.get("org", None)
+    if org:
+        u["org"] = lookup_organisation(org)
+    return u

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -83,11 +83,15 @@ async def login(jwt: Annotated[JWTBearer(), Depends()]):
     local_user = user_db.get_by_id(user_id)
 
     if not local_user:
-        user_db.new_user(user_id, user_email)
-        return {"user_id": user_id, "sharedata": {}}
+        new_user = user_db.new_user(user_id, user_email)
+        return m.LoginResponse.model_validate(
+            {"user": new_user, "new_user": True, "sharedata": {}}
+        )
 
     share_request_forms = share_db.get_request_forms(user_id)
-    return {"user_id": user_id, "sharedata": share_request_forms}
+    return m.LoginResponse.model_validate(
+        {"user": local_user, "new_user": False, "sharedata": share_request_forms}
+    )
 
 
 @app.put("/sharedata")

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -476,7 +476,7 @@ class EditUserOrgRequest(BaseModel):
 class User(BaseModel):
     id: str
     email: EmailStr
-    org: Optional[str] = None
+    org: Optional[Organisation] = None
     role: Optional[str] = None
 
 
@@ -486,11 +486,11 @@ class SPARQLUpdate(BaseModel):
 
 
 class LoginResponse(BaseModel):
-    user_id: str
+    user: User
     new_user: bool
     sharedata: dict[str, ShareData]
 
 
 class CompleteProfileRequest(BaseModel):
-    org: str
+    organisation: str
     role: str

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -477,7 +477,7 @@ class User(BaseModel):
     id: str
     email: EmailStr
     org: Optional[Organisation] = None
-    role: Optional[str] = None
+    jobTitle: Optional[str] = None
 
 
 class SPARQLUpdate(BaseModel):
@@ -493,4 +493,4 @@ class LoginResponse(BaseModel):
 
 class CompleteProfileRequest(BaseModel):
     organisation: str
-    role: str
+    jobTitle: str

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -438,11 +438,6 @@ class ShareData(BaseModel):
     stepHistory: list[str] | None
 
 
-class UpsertUserResponse(BaseModel):
-    user_id: str
-    sharedata: dict[str, ShareData]
-
-
 class UpsertShareDataRequest(BaseModel):
     sharedata: ShareData
 
@@ -482,8 +477,20 @@ class User(BaseModel):
     id: str
     email: EmailStr
     org: Optional[str] = None
+    role: Optional[str] = None
 
 
 class SPARQLUpdate(BaseModel):
     statusCode: int
     message: str
+
+
+class LoginResponse(BaseModel):
+    user_id: str
+    new_user: bool
+    sharedata: dict[str, ShareData]
+
+
+class CompleteProfileRequest(BaseModel):
+    org: str
+    role: str

--- a/api/app/routers/manage_shares.py
+++ b/api/app/routers/manage_shares.py
@@ -1,4 +1,3 @@
-import json
 import datetime
 
 from typing import Annotated, List
@@ -6,10 +5,8 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app import utils
 from app import model as m
-from app.db import user as user_db
 from app.db import share as share_db
-from app.auth.jwt_bearer import JWTBearer, authenticated_user
-from app.auth.utils import ops_user
+from app.auth.jwt_bearer import authenticated_user
 
 router = APIRouter(prefix="/manage-shares")
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -14,8 +14,8 @@ router = APIRouter(prefix="/users")
 async def list_users(is_ops: Annotated[bool, Depends(ops_user)]) -> List[m.User]:
     if not is_ops:
         raise HTTPException(status_code=401, detail="Unauthorised")
-    result = user_db.list_users()
-    return [m.User.model_validate(u) for u in result]
+    users = user_db.list_users()
+    return users
 
 
 @router.get("/me")
@@ -31,12 +31,12 @@ async def complete_profile(
     if user.org:
         raise HTTPException(400, "Organisation already set")
 
-    if profile.org not in utils.orgs.keys():
+    if profile.organisation not in utils.orgs.keys():
         raise HTTPException(
-            status_code=400, detail=f"Invalid organisation: {profile.org}"
+            status_code=400, detail=f"Invalid organisation: {profile.organisation}"
         )
 
-    user_db.complete_profile(user.id, profile.org, profile.role)
+    user_db.complete_profile(user.id, profile.organisation, profile.role)
 
     return user_db.get_by_id(user.id)
 
@@ -46,7 +46,7 @@ async def show_user(
     user_id: str,
     is_ops: Annotated[bool, Depends(ops_user)],
     jwt: Annotated[JWTBearer(auto_error=False), Depends()] = None,
-):
+) -> m.User:
     # If an email address has been provided, turn it into an ID
     if "@" in user_id:
         user_id = utils.user_id_from_email(user_id)
@@ -62,6 +62,20 @@ async def show_user(
             return user_db.get_by_id(authed_user_id)
 
     raise HTTPException(401, "Unauthorised")
+
+
+@router.delete("/{user_id}")
+async def delete_user(
+    user_id: str, is_ops: Annotated[bool, Depends(ops_user)]
+) -> m.SPARQLUpdate:
+    if not is_ops:
+        raise HTTPException(401, "Unauthorised")
+
+    # If an email address has been provided, turn it into an ID
+    if "@" in user_id:
+        user_id = utils.user_id_from_email(user_id)
+
+    return user_db.delete_by_id(user_id)
 
 
 @router.put("/{user_id}/org")

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -36,7 +36,7 @@ async def complete_profile(
             status_code=400, detail=f"Invalid organisation: {profile.organisation}"
         )
 
-    user_db.complete_profile(user.id, profile.organisation, profile.role)
+    user_db.complete_profile(user.id, profile.organisation, profile.jobTitle)
 
     return user_db.get_by_id(user.id)
 

--- a/api/queries/user/complete_profile.sparql
+++ b/api/queries/user/complete_profile.sparql
@@ -1,5 +1,4 @@
 PREFIX schema: <http://schema.org/>
-PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
@@ -7,6 +6,6 @@ INSERT DATA
 { 
       GRAPH cddo_graph:users {
             cddo_user:$user_id  schema:memberOf "$org" ;
-                                cddo:role "$role" .
+                                cddo_user:jobTitle "$jobTitle" .
       }
 }

--- a/api/queries/user/complete_profile.sparql
+++ b/api/queries/user/complete_profile.sparql
@@ -1,0 +1,12 @@
+PREFIX schema: <http://schema.org/>
+PREFIX cddo: <http://marketplace.cddo.gov.uk#>
+PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
+PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
+
+INSERT DATA
+{ 
+      GRAPH cddo_graph:users {
+            cddo_user:$user_id  schema:memberOf "$org" ;
+                                cddo:role "$role" .
+      }
+}

--- a/api/queries/user/delete_by_id.sparql
+++ b/api/queries/user/delete_by_id.sparql
@@ -1,0 +1,12 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX cddo: <http://marketplace.cddo.gov.uk#>
+PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
+
+WITH cddo_graph:users
+DELETE {
+	?user ?p ?o.
+}
+WHERE {
+    ?user dct:identifier "$user_id" ;
+          ?p ?o .
+}

--- a/api/queries/user/get_by_id.sparql
+++ b/api/queries/user/get_by_id.sparql
@@ -1,15 +1,14 @@
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX schema: <http://schema.org/>
-PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?id ?email ?org ?role
+SELECT ?id ?email ?org ?jobTitle
 FROM cddo_graph:users
 WHERE {
     cddo_user:$user_id vcard:hasEmail ?email;
                         dct:identifier ?id .
     OPTIONAL {cddo_user:$user_id schema:memberOf ?org} .
-    OPTIONAL {cddo_user:$user_id cddo:role ?role} .
+    OPTIONAL {cddo_user:$user_id cddo_user:jobTitle ?jobTitle} .
 }

--- a/api/queries/user/get_by_id.sparql
+++ b/api/queries/user/get_by_id.sparql
@@ -5,10 +5,11 @@ PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?id ?email ?org
+SELECT ?id ?email ?org ?role
 FROM cddo_graph:users
 WHERE {
     cddo_user:$user_id vcard:hasEmail ?email;
                         dct:identifier ?id .
-    OPTIONAL {cddo_user:$user_id schema:memberOf ?org}
+    OPTIONAL {cddo_user:$user_id schema:memberOf ?org} .
+    OPTIONAL {cddo_user:$user_id cddo:role ?role} .
 }

--- a/api/queries/user/list.sparql
+++ b/api/queries/user/list.sparql
@@ -4,10 +4,11 @@ PREFIX schema: <http://schema.org/>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?id ?email ?org
+SELECT ?id ?email ?org ?role
 FROM cddo_graph:users
 WHERE {
     ?user dct:identifier ?id;
           vcard:hasEmail ?email .
     OPTIONAL { ?user schema:memberOf ?org } .
+    OPTIONAL { ?user cddo:role ?role } .
 }

--- a/api/queries/user/list.sparql
+++ b/api/queries/user/list.sparql
@@ -1,15 +1,14 @@
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX schema: <http://schema.org/>
-PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?id ?email ?org ?role
+SELECT ?id ?email ?org ?jobTitle
 FROM cddo_graph:users
 WHERE {
     ?user dct:identifier ?id;
           vcard:hasEmail ?email .
     OPTIONAL { ?user schema:memberOf ?org } .
-    OPTIONAL { ?user cddo:role ?role } .
+    OPTIONAL { ?user cddo_user:jobTitle ?jobTitle } .
 }

--- a/api/queries/user/list.sparql
+++ b/api/queries/user/list.sparql
@@ -1,6 +1,7 @@
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX schema: <http://schema.org/>
+PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 


### PR DESCRIPTION
# Complete Your Profile functionality
This PR adds functionality for the [Complete your profile](https://dds-e2e.herokuapp.com/WIP/ben/secure/complete-profile) page.
When a users logs into the Data Marketplace for the first time they are given the option to select their organisation and role.
Once their organisation has been set, they cannot change it.

## Changes
- Updated the `/login` route to return a `new_user` bool, so that the frontend can redirect to the complete-profile page if the user is new.
- Added a `complete-profile` endpoint that first checks if the user's organisation is already set and if the org is valid. Added complete-profile db function & query to update a user's org and role.
- Updated the pydantic model for a User and various users/ API endpoints. Now returning the full user and full org info from the get_user functions. I've also moved the `User` model validation into the `db` function to avoid having to do it in several places.
- Added an endpoint & db stuff for deleting a user based on their ID. Useful for testing the complete you profile stuff because you need to be able to log in as a new user.