### PR TITLE
Search and filter

### DIFF
--- a/api/app/db/asset.py
+++ b/api/app/db/asset.py
@@ -25,6 +25,10 @@ def _construct_AND_terms(terms: List[str]):
 
 
 def _construct_filter(*filter_groups):
+    """A filter_group is a set of filters to apply to a particular property.
+    It has this shape: ["?theme", ["Mapping", "Defence"]]
+    We need to use an OR for values in the same filter group and
+    an AND between different filter groups."""
     if len(filter_groups) == 0:
         return ""
     if all(len(v) == 0 for _, v in filter_groups):

--- a/api/app/db/asset.py
+++ b/api/app/db/asset.py
@@ -1,3 +1,4 @@
+from typing import List
 from app.db.sparql import assets_db
 from app.db import utils as dbutils
 from app import utils
@@ -10,13 +11,41 @@ def _resolve_media_type_label(db_result_dict):
         db_result_dict.pop("mediaTypeLabel")
 
 
-def search(q: str = ""):
+def _construct_OR_terms(property: str, vals: List[str]):
+    if len(vals) == 0:
+        return None
+    terms = " || ".join([f'STR({property}) = "{v}"' for v in vals])
+    return f"({terms})"
+
+
+def _construct_AND_terms(terms: List[str]):
+    terms = [t for t in terms if t]  # Remove Nones
+    terms = " && ".join(terms)
+    return f"({terms})"
+
+
+def _construct_filter(*filter_groups):
+    if len(filter_groups) == 0:
+        return ""
+    if all(len(v) == 0 for _, v in filter_groups):
+        return ""
+    or_terms = [_construct_OR_terms(p, v) for p, v in filter_groups]
+    anded_terms = _construct_AND_terms(or_terms)
+    return f"FILTER ({anded_terms})"
+
+
+def search(q: str = "", organisations: List[str] = [], themes: List[str] = []):
     if q == "":
         q = "*"
+    else:
+        q = f"{q}*"
 
     # TODO What else do we need to do to sanitise the query string?
     q = utils.sanitise_search_query(q)
-    query_results = assets_db.run_query("asset_search", q=q)
+
+    filters = _construct_filter(["?organisation", organisations], ["?theme", themes])
+
+    query_results = assets_db.run_query("asset_search", q=q, filters=filters)
     for r in query_results:
         _resolve_media_type_label(r)
     result_dicts = dbutils.aggregate_query_results_by_key(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -50,7 +50,7 @@ def search_catalogue(
     limit: int = 100,
     offset: int = 0,
 ) -> m.SearchAssetsResponse:
-    assets = asset_db.search(query)
+    assets = asset_db.search(query, organisations=organisation, themes=topic)
     facets = {"topics": [], "organisations": [], "assetTypes": []}
 
     response = {"data": assets, "facets": facets}

--- a/api/queries/asset_search.sparql
+++ b/api/queries/asset_search.sparql
@@ -33,4 +33,5 @@ WHERE {{
     OPTIONAL {{ ?resourceUri dct:type ?serviceType }} .
     OPTIONAL {{ ?resourceUri dcat:theme ?themeURI }
               {?themeURI skos:prefLabel ?theme }} .
+    $filters
 }}

--- a/api/queries/distribution_detail.sparql
+++ b/api/queries/distribution_detail.sparql
@@ -4,7 +4,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/> 
 
-SELECT ?distribution ?title ?modified ?mediaType ?identifier ?license ?issued ?byteSize ?mediaTypeLabel ?externalIdentifier
+SELECT ?distribution ?title ?modified ?mediaType ?identifier ?licence ?issued ?byteSize ?mediaTypeLabel ?externalIdentifier
 FROM cddo_graph:assets
 WHERE {{
     VALUES ?distribution { $distribution }
@@ -12,7 +12,7 @@ WHERE {{
                   dct:modified ?modified ;
                   dcat:mediaType ?mediaTypeUri ;
                   dct:identifier ?identifier ;
-                  dct:license ?license.
+                  dct:license ?licence.
     ?mediaTypeUri rdfs:label ?mediaType .
     OPTIONAL {{ ?mediaTypeUri skos:prefLabel ?mediaTypeLabel }}
     OPTIONAL {{ ?distribution dct:issued ?issued }}


### PR DESCRIPTION
# API Search & Filter
This PR slightly improves the (still very basic) search functionality and adds the ability to filter by organisation & topic.

## Changes
- Added some functions to create a SPARQL `FILTER` statement based on the organisations and themes given in the search query. The filters need to use an `OR` between filters of the same type and an `AND` between filters of different types. I.e. `(organisation = dwp OR cabinet-office) AND (theme = mapping OR transport)`
- Added the filters to the `asset_search` query
- Added a wildcard `*` to the end of the query, so `postcode` will now match `postcodes`. **This will obviously not work for search queries with more than one word, but I don't want to spend any more time on this than we have to**.
- Renamed `license` -> `licence` in the `distribution_detail` SPARQL query, so that it matches what's expected in our Pydantic model