### PR TITLE
Update created requests

### DIFF
--- a/api/app/db/share.py
+++ b/api/app/db/share.py
@@ -1,11 +1,13 @@
 import json
-from app.db.sparql import shares_db
-from app import model as m
+from typing import List
 from datetime import datetime
 
+from app.db.sparql import shares_db
+from app import model as m
 
-def get_request_forms(user_id: str):
-    query_results = shares_db.run_query("get_for_user", user_id=user_id)
+
+def get_sharedata(user_id: str):
+    query_results = shares_db.run_query("get_sharedata", user_id=user_id)
     forms = {r["assetId"]: json.loads(r["sharedata"]) for r in query_results}
     return forms
 
@@ -22,6 +24,11 @@ def upsert_sharedata(user_id: str, sharedata: m.ShareData):
         status=sharedata.status,
     )
     return query_results
+
+
+def created_requests(user_id: str) -> List[m.ShareRequest]:
+    results = shares_db.run_query("get_user_created", user_id=user_id)
+    return results
 
 
 def received_requests(org: str):

--- a/api/app/db/sparql.py
+++ b/api/app/db/sparql.py
@@ -63,5 +63,5 @@ users_db = Connection(
 shares_db = Connection(
     query_url=config.QUERY_URL,
     update_url=config.UPDATE_URL,
-    query_template_dir="queries/shares/",
+    query_template_dir="queries/shares",
 )

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -87,7 +87,7 @@ async def login(jwt: Annotated[JWTBearer(), Depends()]):
             {"user": new_user, "new_user": True, "sharedata": {}}
         )
 
-    share_request_forms = share_db.get_request_forms(user_id)
+    share_request_forms = share_db.get_sharedata(user_id)
     return m.LoginResponse.model_validate(
         {"user": local_user, "new_user": False, "sharedata": share_request_forms}
     )

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -462,7 +462,7 @@ class ShareRequest(BaseModel):
     assetPublisher: Organisation
     received: datetime
     status: ShareRequestStatus
-    sharedata: ShareData
+    sharedata: Optional[ShareData] = None
     neededBy: date | Literal["UNREQUESTED"]
     decisionNotes: Optional[str] = None
     decisionDate: Optional[date] = None

--- a/api/app/routers/manage_shares.py
+++ b/api/app/routers/manage_shares.py
@@ -13,6 +13,8 @@ router = APIRouter(prefix="/manage-shares", tags=["data share"])
 
 def enrich_share_request(r: dict, org: m.Organisation = None) -> dict:
     sharedata = m.ShareData.model_validate_json(r["sharedata"])
+    sharedata.status = r["status"]
+
     neededBy = sharedata.steps["date"].value
     if not (neededBy["day"] and neededBy["month"] and neededBy["year"]):
         neededBy = "UNREQUESTED"
@@ -37,7 +39,7 @@ def enrich_share_request(r: dict, org: m.Organisation = None) -> dict:
 async def created_requests(
     user: Annotated[m.RegisteredUser, Depends(authenticated_user)]
 ) -> List[m.ShareRequest]:
-    share_requests = share_db.get_request_forms(user.id)
+    share_requests = share_db.created_requests(user.id)
     for s in share_requests:
         s["requesterId"] = user.id
     share_requests = [enrich_share_request(s) for s in share_requests]

--- a/api/queries/shares/get_for_user.sparql
+++ b/api/queries/shares/get_for_user.sparql
@@ -1,10 +1,24 @@
+PREFIX schema: <http://schema.org/>
+PREFIX adms: <https://www.w3.org/ns/adms#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cddo: <http://marketplace.cddo.gov.uk#>
+PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?assetId ?sharedata
+SELECT ?requestId ?assetTitle ?assetPublisher ?status ?received ?sharedata 
 FROM cddo_graph:shares
+FROM cddo_graph:assets
+FROM cddo_graph:users
 WHERE {
-  ?share cddo:user "$user_id" ;
-         cddo:asset ?assetId ;
-         cddo:sharedata ?sharedata .
+    ?share 	cddo:asset ?assetId ;
+			cddo:sharedata ?sharedata ;
+			dct:identifier ?requestId ;
+			adms:status ?status ;
+			dct:modified ?received ;
+			cddo:user "?user_id" .
+
+	?asset	dct:identifier ?assetId ;
+            dct:publisher ?assetPublisher ;
+			dct:title ?assetTitle .	
 }

--- a/api/queries/shares/get_sharedata.sparql
+++ b/api/queries/shares/get_sharedata.sparql
@@ -1,0 +1,10 @@
+PREFIX cddo: <http://marketplace.cddo.gov.uk#>
+PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
+
+SELECT ?assetId ?sharedata
+FROM cddo_graph:shares
+WHERE {
+  ?share cddo:user "$user_id" ;
+         cddo:asset ?assetId ;
+         cddo:sharedata ?sharedata .
+}

--- a/api/queries/shares/get_user_created.sparql
+++ b/api/queries/shares/get_user_created.sparql
@@ -6,7 +6,7 @@ PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?requestId ?assetTitle ?assetPublisher ?status ?received ?sharedata 
+SELECT ?requestId ?assetTitle ?assetPublisher ?requesterEmail ?requestingOrg ?status ?received ?sharedata 
 FROM cddo_graph:shares
 FROM cddo_graph:assets
 FROM cddo_graph:users
@@ -16,7 +16,11 @@ WHERE {
 			dct:identifier ?requestId ;
 			adms:status ?status ;
 			dct:modified ?received ;
-			cddo:user "?user_id" .
+			cddo:user "$user_id" .
+
+    ?user	vcard:hasEmail ?requesterEmail ;
+			dct:identifier "$user_id" ;
+			schema:memberOf ?requestingOrg .
 
 	?asset	dct:identifier ?assetId ;
             dct:publisher ?assetPublisher ;


### PR DESCRIPTION
# Updates to Created Requests
I realised that we also need to be fetching the created requests from the API so that the Created Requests page is kept up to date when requests are review.

This PR adds a new `/created-requests` endpoint to fetch a user's requests.
This PR also includes the changes from #22 , some of which were needed to get this to work