### PR TITLE
Add publisher's contact details to a user's share requests

### DIFF
--- a/api/queries/shares/get_user_created.sparql
+++ b/api/queries/shares/get_user_created.sparql
@@ -1,12 +1,13 @@
 PREFIX schema: <http://schema.org/>
 PREFIX adms: <https://www.w3.org/ns/adms#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?requestId ?assetTitle ?assetPublisher ?requesterEmail ?requestingOrg ?status ?received ?sharedata 
+SELECT ?requestId ?assetTitle ?assetPublisher ?publisherContactName ?publisherContactEmail ?requesterEmail ?requestingOrg ?status ?received ?sharedata 
 FROM cddo_graph:shares
 FROM cddo_graph:assets
 FROM cddo_graph:users
@@ -24,5 +25,9 @@ WHERE {
 
 	?asset	dct:identifier ?assetId ;
             dct:publisher ?assetPublisher ;
-			dct:title ?assetTitle .	
+			dct:title ?assetTitle ;
+			dcat:contactPoint ?contact .
+
+	?contact vcard:fn ?publisherContactName ;
+			 vcard:hasEmail ?publisherContactEmail .	
 }


### PR DESCRIPTION
Bugfix: Also add publisher's contact details to a user's share requests, so the created-requests page can return the required info