### PR TITLE
DMBM-913: Supplier Journey

### DIFF
--- a/api/app/routers/manage_shares.py
+++ b/api/app/routers/manage_shares.py
@@ -123,7 +123,10 @@ async def request_decision(
     if share_request["assetPublisher"].slug != user.org.slug:
         raise HTTPException(403, "You are not authorised to review this request")
 
+    decisionNotes = body.decisionNotes.replace("\\", "\\\\").replace('"', '\\"')
+    decisionNotes = "\\n".join(l for l in decisionNotes.splitlines())
+
     result = share_db.upsert_decision(
-        request_id, status=body.status, decisionNotes=body.decisionNotes
+        request_id, status=body.status, decisionNotes=decisionNotes
     )
     return m.SPARQLUpdate.model_validate(result)

--- a/api/app/routers/manage_shares.py
+++ b/api/app/routers/manage_shares.py
@@ -99,7 +99,10 @@ async def review_request(
     if share_request["assetPublisher"].slug != user.org.slug:
         raise HTTPException(403, "You are not authorised to review this request")
 
-    result = share_db.upsert_request_notes(request_id, body.notes)
+    reviewNotes = body.notes.replace("\\", "\\\\").replace('"', '\\"')
+    reviewNotes = "\\n".join(l for l in reviewNotes.splitlines())
+
+    result = share_db.upsert_request_notes(request_id, reviewNotes)
 
     return m.SPARQLUpdate.model_validate(result)
 

--- a/api/queries/shares/get_user_created.sparql
+++ b/api/queries/shares/get_user_created.sparql
@@ -7,7 +7,7 @@ PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_user: <http://marketplace.cddo.gov.uk/user/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
-SELECT ?requestId ?assetTitle ?assetPublisher ?publisherContactName ?publisherContactEmail ?requesterEmail ?requestingOrg ?status ?received ?sharedata 
+SELECT ?requestId ?assetTitle ?assetPublisher ?publisherContactName ?publisherContactEmail ?requesterEmail ?requestingOrg ?status ?received ?sharedata ?decisionDate
 FROM cddo_graph:shares
 FROM cddo_graph:assets
 FROM cddo_graph:users
@@ -18,6 +18,8 @@ WHERE {
 			adms:status ?status ;
 			dct:modified ?received ;
 			cddo:user "$user_id" .
+	
+	OPTIONAL {{ ?share cddo:decisionDate ?decisionDate . }}
 
     ?user	vcard:hasEmail ?requesterEmail ;
 			dct:identifier "$user_id" ;

--- a/api/queries/shares/upsert_notes.sparql
+++ b/api/queries/shares/upsert_notes.sparql
@@ -1,14 +1,18 @@
+PREFIX adms: <https://www.w3.org/ns/adms#>
 PREFIX cddo: <http://marketplace.cddo.gov.uk#>
 PREFIX cddo_share: <http://marketplace.cddo.gov.uk/share/>
 PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
 WITH cddo_graph:shares
 DELETE {
-    cddo_share:$request_id  cddo:reviewNotes ?notes .
+    cddo_share:$request_id  cddo:reviewNotes ?notes ;
+                            adms:status ?status .
 }
 INSERT {
-    cddo_share:$request_id  cddo:reviewNotes "$notes" .
+    cddo_share:$request_id cddo:reviewNotes "$notes" ;
+                           adms:status "IN REVIEW" .
 }
 WHERE {
-    OPTIONAL{ cddo_share:$request_id  cddo:reviewNotes ?notes } .
+    OPTIONAL{ cddo_share:$request_id cddo:reviewNotes ?notes } .
+    OPTIONAL{ cddo_share:$request_id adms:status ?status } .
 }


### PR DESCRIPTION
# Supplier Journey
This PR adds a few fixes & changes for things that the frontend needed for Supplier Journey.

## Changes
- There are a couple of places where suppliers can enter text, when reviewing share requests and making their decision. Previously everything broke when trying to submit text that contained newlines or quotes. This is now fixed, using the same code that @madelinekosse used in #29.
- When a supplier submits some review notes we also update the share request to have a status of `IN REVIEW`
- Add the `decisionDate` to the data returned when a user views their share requests, so it can be displayed in the Created Requests table 