### PR TITLE
Bugfixes/form contact and mimetype label

### DIFF
--- a/api/app/model.py
+++ b/api/app/model.py
@@ -438,9 +438,9 @@ class ShareData(BaseModel):
     ownedBy: str
     completedSections: int
     status: str
+    contactPoint: ContactPoint | None = None
     overviewSections: dict[str, ShareDataSection]
     steps: dict[str, ShareDataStep]
-    stepHistory: list[str] | None
 
 
 class UpsertShareDataRequest(BaseModel):

--- a/fuseki/data/mimetype-labels.ttl
+++ b/fuseki/data/mimetype-labels.ttl
@@ -19,4 +19,4 @@ text:csv skos:prefLabel "CSV" .
 <https://w3id.org/uri4uri/mime/application/gml+xml> skos:prefLabel "GML" .
 <https://w3id.org/uri4uri/mime/application/vnd.google-earth.kml+xml> skos:prefLabel "KML" .
 <https://w3id.org/uri4uri/mime/application/vnd.shp> skos:prefLabel "SHP" .
-<https://w3id.org/uri4uri/mime/application/vnd.oasis.opendocument.spreadsheet> skos:prefLabel "OASIS" .
+<https://w3id.org/uri4uri/mime/application/vnd.oasis.opendocument.spreadsheet> skos:prefLabel "ODS" .


### PR DESCRIPTION
# Bug Party fixes
This PR contains a couple of small fixes for issues found in the bug party.

## Changes
- The contactPoint info has been missed from the ShareData model, so that info has not been being saved to the database properly.
- Also removed `stepHistory` from `ShareData` because that's not used any more, now that the back links on the frontend are fixed.
- Renamed `OASIS` to `ODS`