### PR TITLE
Fuseki backup prep

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     build:
       context: fuseki
       dockerfile: Dockerfile
+    environment:
+      - ADMIN_PASSWORD
     # volumes:
       # - fuseki_storage:/fuseki-base/databases
     ports:

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,5 +1,9 @@
 FROM secoresearch/fuseki
 
+USER root
+RUN apt-get install -qq curl
+USER 9008
+
 COPY --chown=9008 data /tmp/data
 COPY assembler.ttl /fuseki-base/configuration/assembler.ttl
 


### PR DESCRIPTION
It's possible to backup and restore Fuseki using its its API, but only if you're calling it from the same machine that Fuseki is running on (i.e. from within the docker container)

I've added curl to the fuseki container so that we can make some scripts to backup the database.

Also now passing through an ADMIN_PASSWORD env variable to Fuseki so that we can specify our own admin password if necessary(which is needed to call the backup API endpoint)