### PR TITLE
More infomative errors in CSV row error object

### DIFF
--- a/api/app/publish/csv.py
+++ b/api/app/publish/csv.py
@@ -275,6 +275,7 @@ def parse_input_file(
                     else d["title"],
                     "scope": errorScope.asset,
                     "sub_errors": validation_errors,
+                    "extras": {"input_data": d},
                 }
             )
     return validated_data

--- a/api/app/publish/errors.py
+++ b/api/app/publish/errors.py
@@ -82,7 +82,7 @@ def validation_error_info(e: ValidationError) -> List[ErrorInfo]:
             {
                 "scope": errorScope.field,
                 "location": field_name,
-                "value": err["input"],
+                "value": "" if err["type"] == "missing" else err["input"],
                 **info,
             }
         )


### PR DESCRIPTION
For a validation error on a single asset:

* Include an additional `input_data` key within the error's `extra` field so the front end can use the name/type/etc

* When the validation error refers to a missing value, include the empty string in the `value` field within the extras. Pydantic's default is to include the entire data structure, which seems odd since other validation errors will include the field value that caused the problem.