### PR TITLE
DMBM 1049: Bugfix permissions

### DIFF
--- a/api/app/db/user.py
+++ b/api/app/db/user.py
@@ -66,7 +66,7 @@ def complete_profile(user_id, org, jobTitle):
 
 def edit_permissions(user_id, permissions_to_add, permissions_to_remove):
     to_add = [f'"{val}"' for val in permissions_to_add]
-    res = {"status": 200, "message": "no update required"}
+    res = {"statusCode": 200, "message": "no update required"}
     if permissions_to_remove != []:
         res = users_db.run_update(
             "remove_permissions",

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -166,6 +166,9 @@ async def edit_user_permissions(
     user_id: str,
     req: m.EditUserPermissionRequest,
 ):
+    if not is_ops:
+        raise HTTPException(status_code=401, detail="Unauthorised")
+
     # If an email address has been provided, turn it into an ID
     if "@" in user_id:
         user_id = utils.user_id_from_email(user_id)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"

--- a/api/test/.env.example
+++ b/api/test/.env.example
@@ -1,0 +1,2 @@
+URL=http://localhost:8000
+OPS_API_KEY=<API_KEY>

--- a/api/test/README.md
+++ b/api/test/README.md
@@ -1,0 +1,9 @@
+# Integration testing with Hurl
+## Prerequisites
+- Install [just](https://github.com/casey/just)
+- Install [Hurl](https://hurl.dev/)
+
+## Usage
+- Copy `.env.examaple` to `.env` and update the `OPS_API_KEY` to match the one used in the `.env` file in the `api/` directory.
+- Start the API (e.g. by using `just run` from the root directory) and ensure that there is at least one user in the database (the easiest way would be to also start the frontend and log in via the SSO).
+- Run the tests: `just test` (or `cd` into the `test` directory and use `hurl --test --variables-file=.env admin_routes.hurl`)

--- a/api/test/admin_routes.hurl
+++ b/api/test/admin_routes.hurl
@@ -1,0 +1,135 @@
+# ***********************
+# *     LIST USERS      *
+# ***********************
+
+# API returns 401 if no key is provided
+GET {{URL}}/users
+HTTP 401
+
+# API returns 401 if incorrect key is provided
+GET {{URL}}/users
+x-api-key: A
+HTTP 401
+
+# API returns 200 if correct key is provided
+GET {{URL}}/users
+x-api-key: {{OPS_API_KEY}}
+HTTP 200
+[Captures]
+user_id: jsonpath "$[0]['@id']"
+
+
+# ************************
+# *     DELETE USER      *
+# ************************
+
+# API returns 401 if no key is provided
+DELETE {{URL}}/users/{{user_id}}
+HTTP 401
+
+# API returns 401 if incorrect key is provided
+GET {{URL}}/users/{{user_id}}
+x-api-key: A
+HTTP 401
+
+
+# ***********************
+# *     SET ORG         *
+# ***********************
+
+# API returns 401 if no key is provided
+PUT {{URL}}/users/{{user_id}}/org
+Content-Type: application/json
+{
+    "org": "ofsted"
+}
+HTTP 401
+
+# API returns 401 if incorrect key is provided
+PUT {{URL}}/users/{{user_id}}/org
+x-api-key: A
+Content-Type: application/json
+{
+    "org": "ofsted"
+}
+HTTP 401
+
+# API returns 200 if correct key is provided
+PUT {{URL}}/users/{{user_id}}/org
+x-api-key: {{OPS_API_KEY}}
+Content-Type: application/json
+{
+    "org": "ofsted"
+}
+HTTP 200
+
+# Check that the user's org has been updated
+GET {{URL}}/users/{{user_id}}
+x-api-key: {{OPS_API_KEY}}
+HTTP 200
+[Asserts]
+jsonpath "$.org.slug" == "ofsted"
+
+
+# ************************
+# *     PERMISSIONS      *
+# ************************
+
+# API returns 401 if no key is provided
+PUT {{URL}}/users/{{user_id}}/permissions
+Content-Type: application/json
+{
+    "add": ["OPS", "ADMINISTRATOR"],
+    "remove": ["SHARE_REVIEWER", "PUBLISHER"]
+}
+HTTP 401
+
+# API returns 401 if incorrect key is provided
+PUT {{URL}}/users/{{user_id}}/permissions
+x-api-key: A
+Content-Type: application/json
+{
+    "add": ["OPS", "ADMINISTRATOR"],
+    "remove": ["SHARE_REVIEWER", "PUBLISHER"]
+}
+HTTP 401
+
+# API returns 200 if the correct key is provided
+PUT {{URL}}/users/{{user_id}}/permissions
+x-api-key: {{OPS_API_KEY}}
+Content-Type: application/json
+{
+    "add": ["OPS", "ADMINISTRATOR"],
+    "remove": ["SHARE_REVIEWER", "PUBLISHER"]
+}
+HTTP 200
+
+# Check that the user's permissions have been updated
+GET {{URL}}/users/{{user_id}}
+x-api-key: {{OPS_API_KEY}}
+HTTP 200
+[Asserts]
+jsonpath "$.permission" includes "OPS"
+jsonpath "$.permission" includes "ADMINISTRATOR"
+jsonpath "$.permission" not includes "SHARE_REVIEWER"
+jsonpath "$.permission" not includes "PUBLISHER"
+
+# Swap the permissions and check again
+PUT {{URL}}/users/{{user_id}}/permissions
+x-api-key: {{OPS_API_KEY}}
+Content-Type: application/json
+{
+    "remove": ["OPS", "ADMINISTRATOR"],
+    "add": ["SHARE_REVIEWER", "PUBLISHER"]
+}
+HTTP 200
+
+# Check that the user's permissions have been updated
+GET {{URL}}/users/{{user_id}}
+x-api-key: {{OPS_API_KEY}}
+HTTP 200
+[Asserts]
+jsonpath "$.permission" not includes "OPS"
+jsonpath "$.permission" not includes "ADMINISTRATOR"
+jsonpath "$.permission" includes "SHARE_REVIEWER"
+jsonpath "$.permission" includes "PUBLISHER"

--- a/justfile
+++ b/justfile
@@ -14,3 +14,6 @@ setup-hooks:
 
 generate-spec-file:
   curl localhost:8000/openapi.json | yq eval -P > openapi.yaml
+
+test:
+  cd api/test && hurl --test --variables-file=.env admin_routes.hurl


### PR DESCRIPTION
# Bugfix in permissions API
Soydaner spotted that it's possible to successfully call the change permissions API without passing a API key.
This PR fixes that.

## Changes
- Return `401` from the permissions endpoint if the user did not pass the correct `OPS-API-KEY`
- Added some tests to the `test` directory which use [Hurl](https://hurl.dev/) to ensure that all of the admin routes require an api key to be passed in the headers