### PR TITLE
Bugfix: dates, externalIDs, licences

### DIFF
--- a/api/app/model.py
+++ b/api/app/model.py
@@ -124,7 +124,7 @@ class DistributionSummary(BaseModel):
     licence: AnyUrl | None = "http://marketplace.cddo.gov.uk/licence/internal"
     modified: PastDate | None = None
     accessService: str | None = None
-    externalIdentifier: str
+    externalIdentifier: str | None = None
     issued: PastDate | None = None
     byteSize: PositiveInt | None = None
 

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -166,7 +166,7 @@ class BaseAsset(BaseAssetSummary):
     relatedAssets: List[AnyUrl | AssetForHref] | None = []
     securityClassification: securityClassification
     summary: str | None = None
-    version: str | None = "1.0"
+    version: str
     externalIdentifier: str
 
     class Config:

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -162,7 +162,9 @@ class BaseAsset(BaseAssetSummary):
     description: str
     issued: PastDate | None = None
     keyword: List[str] | None = []
-    licence: AnyUrl | None = "http://marketplace.cddo.gov.uk/licence/internal"
+    licence: AnyUrl | Literal[
+        "DATA_SHARE_REQUEST"
+    ] | None = "http://marketplace.cddo.gov.uk/licence/internal"
     relatedAssets: List[AnyUrl | AssetForHref] | None = []
     securityClassification: securityClassification
     summary: str | None = None

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -121,7 +121,7 @@ PastDate = Annotated[datetime, AfterValidator(check_date_past)]
 class DistributionSummary(BaseModel):
     title: str
     mediaType: str
-    licence: AnyUrl | None = "http://marketplace.cddo.gov.uk/licence/internal"
+    licence: str | None = "http://marketplace.cddo.gov.uk/licence/internal"
     modified: PastDate | None = None
     accessService: str | None = None
     externalIdentifier: str | None = None

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -121,7 +121,7 @@ PastDate = Annotated[datetime, AfterValidator(check_date_past)]
 class DistributionSummary(BaseModel):
     title: str
     mediaType: str
-    licence: str | None = "http://marketplace.cddo.gov.uk/licence/internal"
+    licence: AnyUrl | Literal["DATA_SHARE_REQUEST"] | None = None
     modified: PastDate | None = None
     accessService: str | None = None
     externalIdentifier: str | None = None
@@ -162,9 +162,7 @@ class BaseAsset(BaseAssetSummary):
     description: str
     issued: PastDate | None = None
     keyword: List[str] | None = []
-    licence: AnyUrl | Literal[
-        "DATA_SHARE_REQUEST"
-    ] | None = "http://marketplace.cddo.gov.uk/licence/internal"
+    licence: AnyUrl | Literal["DATA_SHARE_REQUEST"]
     relatedAssets: List[AnyUrl | AssetForHref] | None = []
     securityClassification: securityClassification
     summary: str | None = None

--- a/api/app/publish/create_asset.py
+++ b/api/app/publish/create_asset.py
@@ -54,9 +54,7 @@ def create_assets(assets: List[m.CreateDatasetBody | m.CreateDataServiceBody]):
                 {
                     "message": "Can't store asset data",
                     "scope": errorScope.asset,
-                    "location": a["externalIdentifier"]
-                    if a["externalIdentifier"] is not None
-                    else a["title"],
+                    "location": a.get("externalIdentifier", a.get("title")),
                     "extras": {"error": str(e)},
                 }
             )

--- a/api/app/publish/csv.py
+++ b/api/app/publish/csv.py
@@ -265,7 +265,7 @@ def _validate_db_fields(asset):
             )
     for t in asset.get("theme", []):
         if err := _validation_error(reference_data_validator.theme_uri, t):
-            errors.append(db_validation_error_info("theme", t), err)
+            errors.append(db_validation_error_info("theme", t, err))
     return errors
 
 

--- a/api/app/publish/csv.py
+++ b/api/app/publish/csv.py
@@ -139,7 +139,12 @@ def _cleanup_csv_row_dict(row_dict):
     for date_field in date_fields:
         if date_field in row_dict:
             try:
-                parsed_date = dateparser.parse(row_dict[date_field], locales=["en-GB"])
+                try:
+                    parsed_date = datetime.fromisoformat(row_dict[date_field])
+                except ValueError:
+                    parsed_date = dateparser.parse(
+                        row_dict[date_field], locales=["en-GB"]
+                    )
                 row_dict[date_field] = parsed_date
             except ValueError as e:
                 print(e)

--- a/api/app/publish/csv.py
+++ b/api/app/publish/csv.py
@@ -145,6 +145,9 @@ def _cleanup_csv_row_dict(row_dict):
                     parsed_date = dateparser.parse(
                         row_dict[date_field], locales=["en-GB"]
                     )
+                    if not parsed_date:
+                        parsed_date = dateparser.parse(row_dict[date_field])
+
                 row_dict[date_field] = parsed_date
             except ValueError as e:
                 print(e)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.3.3"
+version = "0.3.4"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.3.4"
+version = "0.3.5"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"

--- a/api/queries/asset_detail.sparql
+++ b/api/queries/asset_detail.sparql
@@ -10,7 +10,7 @@ PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
 
 SELECT ?resourceUri ?updateFrequency ?endpointDescription ?endpointURL ?serviceStatus ?serviceType ?accessRights
 ?contactName ?contactEmail ?contactAddress ?contactTelephone ?created ?description ?issued
-?licence ?modified ?organisation ?securityClassification ?summary ?title ?type ?catalogueCreated ?catalogueModified ?creator ?keyword ?alternativeTitle ?relatedAssets ?theme ?servesDataset ?distribution ?externalIdentifier
+?licence ?modified ?organisation ?securityClassification ?summary ?title ?type ?version ?catalogueCreated ?catalogueModified ?creator ?keyword ?alternativeTitle ?relatedAssets ?theme ?servesDataset ?distribution ?externalIdentifier
 FROM cddo_graph:assets
 WHERE {{
 ?resourceUri dct:identifier "$asset_id" ;

--- a/api/test/asset_details.hurl
+++ b/api/test/asset_details.hurl
@@ -1,0 +1,33 @@
+# *******************************************************
+# *  These tests simply try to GET each sample asset    *
+# *     in the database, to make sure that each asset   *
+# *     satisfies the Pydantic model.                   *
+# *******************************************************
+
+# Address lookup
+GET {{URL}}/catalogue/fcbc4d3f-0c05-4857-b0e3-eeec6bfea3a1
+HTTP 200
+
+# OS Postcodes
+GET {{URL}}/catalogue/b3ae48af-c130-44ac-8341-5dead13c5427
+HTTP 200
+
+# Bathing Water
+GET {{URL}}/catalogue/cd62b912-60fb-427a-bf87-a3b7c2364e6d
+HTTP 200
+
+# Bathing Water Monitoring Locations
+GET {{URL}}/catalogue/e45b6315-88dd-4e2a-bb0e-0846bbfa4fd3
+HTTP 200
+
+# MoJ Data First Crown Court defendant case level dataset
+GET {{URL}}/catalogue/f0a166b6-13e0-43c3-ad97-9f835f7088dd
+HTTP 200
+
+# MoJ Data First magistrates' court defendant case level dataset
+GET {{URL}}/catalogue/3feff58c-faaf-484b-a436-8a80d918e6fa
+HTTP 200
+
+# Interest Restriction Return (IRR) API
+GET {{URL}}/catalogue/debc41c4-159c-4c74-99de-88af20b499a2
+HTTP 200

--- a/justfile
+++ b/justfile
@@ -19,4 +19,4 @@ generate-spec-file:
   curl localhost:8000/openapi.json | yq eval -P > openapi.yaml
 
 test:
-  cd api/test && hurl --test --variables-file=.env admin_routes.hurl
+  cd api/test && hurl --test --variables-file=.env admin_routes.hurl && hurl --test --variables-file=.env asset_details.hurl


### PR DESCRIPTION
# Bugfixes
This PR address the bugs described in [DMBM-1085](https://cddodatamarketplace.atlassian.net/browse/DMBM-1085), [DMBM-1086](https://cddodatamarketplace.atlassian.net/browse/DMBM-1086) and [DMBM-1087](https://cddodatamarketplace.atlassian.net/browse/DMBM-1087), which are all related to the validation of uploaded spreadsheets.

## Changes
### Licences
- Updated `model.py` to allow the literal string `DATA_SHARE_REQUEST` as a licence for a data asset.
- Updated the distribution model to allow the dsitribution licence to be any string, based on @AlasdairGray 's comment on Slack:  
`the validator should still pick up about the modified field and the licence for the dataset (but not worry about the distributions)` which I've interpreted as "the validator doesn't need to worry about distribution licences - any string will do".

### External IDs
Previously I made distribution external identifiers a required field, but that is not what we want at the moment (see [DMBM-1086](https://cddodatamarketplace.atlassian.net/browse/DMBM-1086))

### Dates
The [dateparser](https://dateparser.readthedocs.io/en/latest/) library that I added to try and make sure that dates are parsed in UK format struggles with ISO8601 format dates. There are various GitHub issues related to this, e.g. ["ISO8601 parsing depends on locale"](https://github.com/scrapinghub/dateparser/issues/1125). As a workaround I now try and parse the date using the built-in [datetime.fromisoformat](https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat) function, and if that fails then fall back to `dateparser`. I.e. so `dateparser` never needs to try and parse an ISO format date.