### PR TITLE
Fix explore crash bug

### DIFF
--- a/api/app/model.py
+++ b/api/app/model.py
@@ -124,7 +124,7 @@ class DistributionSummary(BaseModel):
     licence: AnyUrl | None = "http://marketplace.cddo.gov.uk/licence/internal"
     modified: PastDate | None = None
     accessService: str | None = None
-    externalIdentifier: str
+    externalIdentifier: str | None = None
     issued: PastDate | None = None
     byteSize: PositiveInt | None = None
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.3.3"
+version = "0.3.4"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"


### PR DESCRIPTION
The marketplace is currently crashing when trying to view data assets with distributions that do not have an external identifier.

this PR relaxes the need for the external identifier for a distribution to be present.

the PR increases the patch release number.