### PR TITLE
DMBM-1092: Media type error message

### DIFF
--- a/api/app/publish/csv.py
+++ b/api/app/publish/csv.py
@@ -252,7 +252,10 @@ def _validate_db_fields(asset):
             ):
                 errors.append(
                     db_validation_error_info(
-                        "distribution.mediaType", dist.get("mediaType", ""), err
+                        "distribution.mediaType",
+                        dist.get("mediaType", ""),
+                        err
+                        + '. Please use a <a href="https://co-cddo.github.io/ukgov-metadata-exchange-model/mediaType/"> valid mediaType</a>.',
                     )
                 )
         if err := _validation_error(

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cddo-dm-api"
-version = "0.3.5"
+version = "0.3.6"
 description = ""
 authors = ["Kiran Joshi <kiran.joshi@tpximpact.com>", "Madeline Kosse <madeline.kosse@tpximpact.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Media Type errors
This PR address the issue described in [DMBM-1092](https://cddodatamarketplace.atlassian.net/browse/DMBM-1092) and adds some details to the error message produced if uploaded metadata about a data asset distribution does not contain a valid `mediaType`.
## Changes
- Error messages about invalid media types now include a link to the [mediaType part of the Metadata Exchange Model site](https://co-cddo.github.io/ukgov-metadata-exchange-model/mediaType/)
![image](https://github.com/co-cddo/data-marketplace-api/assets/1217533/35e20291-8098-4f61-9ff0-0d1295580fbf)
