### PR TITLE
Publish dashboard asset counts API

### DIFF
--- a/api/app/db/asset.py
+++ b/api/app/db/asset.py
@@ -122,3 +122,8 @@ def detail(asset_id: str):
 
     asset["description"] = dbutils.unwrap_markdown(asset["description"])
     return asset
+
+
+def counts_by_org(org: str):
+    query_results = assets_db.run_query("asset_counts_by_org", org=org)
+    return query_results

--- a/api/app/model.py
+++ b/api/app/model.py
@@ -552,3 +552,8 @@ class ReviewRequest(BaseModel):
 class DecisionRequest(BaseModel):
     status: ShareRequestDecisionStatus
     decisionNotes: str
+
+
+class AssetCountsResponse(BaseModel):
+    Dataset: int
+    DataService: int

--- a/api/queries/asset_counts_by_org.sparql
+++ b/api/queries/asset_counts_by_org.sparql
@@ -1,0 +1,13 @@
+PREFIX cddo_graph: <http://marketplace.cddo.gov.uk/graph/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?assetLabel (COUNT(?assetLabel) as ?count)
+FROM cddo_graph:assets
+WHERE {
+  ?asset a ?assetType ;
+  		 dct:publisher "$org".
+
+  ?assetType rdfs:label ?assetLabel.
+}
+GROUP BY ?assetLabel


### PR DESCRIPTION
# Publish dashboard counts
This PR adds a new API endpoint to get the number of data assets published by a particular organisation.

## Changes
- Added a new `/asset-counts` endpoint that needs to be passed a valid JWT to determine which organisation the user belongs to.
- Added a new SPARQL query to get and count the number of Datasets and DataServices that have a `dcat:publisher` equal to a given organisation.